### PR TITLE
KAS-4711 add order by to query to avoid using inherent pagination

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: feature/*
+when:
+  event: push
+  branch: feature/*

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: latest
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: [master, main]
+when:
+  event: push
+  branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
     secrets: [ docker_username, docker_password ]
-    when:
-      event: tag
-      tag: v*
+when:
+  event: tag
+  tag: v*

--- a/lib/graph-helpers.js
+++ b/lib/graph-helpers.js
@@ -21,7 +21,7 @@ async function getGraphTriples(graph) {
           ?subject ?predicate ?object .
         }
       }
-      LIMIT ${SELECT_BATCH_SIZE} OFFSET %OFFSET
+      ORDER BY ?subject LIMIT ${SELECT_BATCH_SIZE} OFFSET %OFFSET
     `;
 
     while (offset < count) {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4711

Query with LIMIT and OFFSET without ORDER BY may lead to missing/duplicate triples if inherent pagination changes.
Discovered in `dcat-dataset-publication` service.
Similar query happens in this repo.